### PR TITLE
indexByte → indexRune

### DIFF
--- a/httpd/2/httpd/request.go
+++ b/httpd/2/httpd/request.go
@@ -80,7 +80,7 @@ func parseQuery(RawQuery string) map[string]string {
 	parts := strings.Split(RawQuery, "&")
 	queries := make(map[string]string, len(parts))
 	for _, part := range parts {
-		index := strings.IndexByte(part, '=')
+		index := strings.IndexRune(part, '=')
 		if index == -1 || index == len(part)-1 {
 			continue
 		}


### PR DESCRIPTION
虽然 `indexRune` 底层调用了 `indexByte`，但是 `'='` 本身表达了 `rune` 的含义，个人感觉使用 `indexRune` 会有更强的可读性。